### PR TITLE
[DFU] Make the jump to app a user-implemented call

### DIFF
--- a/inc/voyager.h
+++ b/inc/voyager.h
@@ -38,7 +38,6 @@ typedef enum {
     VOYAGER_NVM_KEY_APP_START_ADDRESS,
     VOYAGER_NVM_KEY_APP_END_ADDRESS,  // Used to ensure the app size does not
                                       // exceed the max bound
-    VOYAGER_NVM_KEY_APP_RESET_VECTOR_ADDRESS,
     VOYAGER_NVM_KEY_APP_SIZE,
     VOYAGER_NVM_KEY_VERIFY_FLASH_BEFORE_JUMPING,
 } voyager_nvm_key_E;
@@ -59,7 +58,6 @@ typedef union {
     voyager_bootloader_app_crc_t app_crc;
     voyager_bootloader_addr_size_t app_start_address;
     voyager_bootloader_addr_size_t app_end_address;
-    voyager_bootloader_addr_size_t app_reset_vector_address;
     voyager_bootloader_app_size_t app_size;
     voyager_bootloader_verify_flash_before_jumping_t verify_flash_before_jumping;
 } voyager_bootloader_nvm_data_t;
@@ -171,5 +169,13 @@ voyager_error_E voyager_bootloader_hal_erase_flash(const voyager_bootloader_addr
  */
 voyager_error_E voyager_bootloader_hal_write_flash(const voyager_bootloader_addr_size_t address, void const *const data,
                                                    size_t const length);
+
+/**
+ * @brief voyager_bootloader_hal_jump_to_app Jumps to the application
+ * @param app_start_address The start address of the application
+ * @return VOYAGER_ERROR_NONE if successful, otherwise an error code
+ * @note This function is called by the bootloader and is required to be implemented by the application
+ */
+voyager_error_E voyager_bootloader_hal_jump_to_app(const voyager_bootloader_addr_size_t app_start_address);
 
 #endif  // VOYAGER_H

--- a/inc/voyager_private.h
+++ b/inc/voyager_private.h
@@ -56,11 +56,6 @@ typedef struct {
     };
 } voyager_message_t;
 
-typedef union {
-    void (*func)(void);
-    voyager_bootloader_nvm_data_t addr;
-} reset_vector_U;
-
 typedef enum {
     VOYAGER_MESSAGE_ID_UNKNOWN = 0,
     VOYAGER_MESSAGE_ID_START,

--- a/src/voyager.c
+++ b/src/voyager.c
@@ -214,17 +214,14 @@ voyager_error_E voyager_private_run_state(const voyager_bootloader_state_E state
                     }
                 }
 
-                // Jump to the app!
-                voyager_bootloader_nvm_data_t app_reset_vector_address;
-                ret = voyager_bootloader_nvm_read(VOYAGER_NVM_KEY_APP_RESET_VECTOR_ADDRESS, &app_reset_vector_address);
+                // Get the app start address
+                ret = voyager_bootloader_nvm_read(VOYAGER_NVM_KEY_APP_START_ADDRESS, &data);
                 if (ret != VOYAGER_ERROR_NONE) {
                     break;
                 }
 
-                // Call the reset vector
-                reset_vector_U reset_vector;
-                reset_vector.addr = app_reset_vector_address;
-                reset_vector.func();
+                // Jump to the app!
+                ret = voyager_bootloader_hal_jump_to_app(data.app_start_address);
             } break;
 
             case VOYAGER_STATE_DFU_RECEIVE: {

--- a/test/mocks/mock_dfu.c
+++ b/test/mocks/mock_dfu.c
@@ -7,7 +7,13 @@
 
 static uint8_t fake_flash[FAKE_FLASH_SIZE] = {0};
 
-void mock_reset_vector(void) { mock_c()->actualCall("mock_reset_vector"); }
+voyager_error_E voyager_bootloader_hal_jump_to_app(const voyager_bootloader_addr_size_t app_start_address) {
+    mock_c()
+        ->actualCall("voyager_bootloader_hal_jump_to_app")
+        ->withUnsignedLongIntParameters("app_start_address", app_start_address);
+
+    return (voyager_error_E)mock_c()->returnValue().value.intValue;
+}
 
 void mock_dfu_init(void) {
     // memcpy the fake flash data 0 to fake_flash

--- a/test/mocks/mock_dfu.h
+++ b/test/mocks/mock_dfu.h
@@ -12,8 +12,6 @@ const uint8_t fake_flash_data_1[FAKE_FLASH_SIZE] = {
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
 };
 
-void mock_reset_vector(void);
-
 void mock_dfu_init(void);
 
 uint8_t *mock_dfu_get_flash(void);

--- a/test/mocks/mock_nvm.c
+++ b/test/mocks/mock_nvm.c
@@ -27,9 +27,6 @@ voyager_error_E voyager_bootloader_nvm_write(const voyager_nvm_key_E key, voyage
         case VOYAGER_NVM_KEY_VERIFY_FLASH_BEFORE_JUMPING: {
             mock_nvm_data.verify_flash_before_jumping = data->verify_flash_before_jumping;
         } break;
-        case VOYAGER_NVM_KEY_APP_RESET_VECTOR_ADDRESS: {
-            mock_nvm_data.app_reset_vector_address = data->app_reset_vector_address;
-        } break;
         default: {
             error = VOYAGER_ERROR_INVALID_ARGUMENT;
         } break;
@@ -55,9 +52,6 @@ voyager_error_E voyager_bootloader_nvm_read(const voyager_nvm_key_E key, voyager
         } break;
         case VOYAGER_NVM_KEY_VERIFY_FLASH_BEFORE_JUMPING: {
             data->verify_flash_before_jumping = mock_nvm_data.verify_flash_before_jumping;
-        } break;
-        case VOYAGER_NVM_KEY_APP_RESET_VECTOR_ADDRESS: {
-            data->app_reset_vector_address = mock_nvm_data.app_reset_vector_address;
         } break;
         default: {
             error = VOYAGER_ERROR_INVALID_ARGUMENT;

--- a/test/mocks/mock_nvm.h
+++ b/test/mocks/mock_nvm.h
@@ -8,7 +8,6 @@ typedef struct {
     voyager_bootloader_app_crc_t app_crc;
     voyager_bootloader_addr_size_t app_start_address;
     voyager_bootloader_addr_size_t app_end_address;
-    voyager_bootloader_addr_size_t app_reset_vector_address;
     voyager_bootloader_app_size_t app_size;
     voyager_bootloader_verify_flash_before_jumping_t verify_flash_before_jumping;
 } mock_nvm_data_t;

--- a/test/test_bootloader.cpp
+++ b/test/test_bootloader.cpp
@@ -14,7 +14,6 @@ TEST_GROUP(test_bootloader_state_machine){
 
     void setup(){mock().clear();
 mock_nvm_data_t *nvm_data = mock_nvm_get_data();
-nvm_data->app_reset_vector_address = (uintptr_t)&mock_reset_vector;
 
 uint8_t *mock_app_start_address = mock_dfu_get_flash();
 nvm_data->app_start_address = (uintptr_t)mock_app_start_address;
@@ -69,7 +68,10 @@ TEST(test_bootloader_state_machine, test_bootloader_jumps_to_application_on_requ
     CHECK_EQUAL(VOYAGER_STATE_JUMP_TO_APP, voyager_private_get_desired_state());
 
     // Check that the reset vector is called
-    mock().expectOneCall("mock_reset_vector");
+    mock()
+        .expectOneCall("voyager_bootloader_hal_jump_to_app")
+        .withUnsignedLongLongIntParameter("app_start_address", nvm_data->app_start_address)
+        .andReturnValue(VOYAGER_ERROR_NONE);
     CHECK_EQUAL(VOYAGER_ERROR_NONE, voyager_bootloader_run());
     mock().checkExpectations();
 
@@ -125,7 +127,10 @@ TEST(test_bootloader_state_machine, test_app_good_crc_verify) {
     CHECK_EQUAL(VOYAGER_STATE_JUMP_TO_APP, voyager_private_get_desired_state());
 
     // Check that the reset vector is called
-    mock().expectOneCall("mock_reset_vector");
+    mock()
+        .expectOneCall("voyager_bootloader_hal_jump_to_app")
+        .withUnsignedLongLongIntParameter("app_start_address", nvm_data->app_start_address)
+        .andReturnValue(VOYAGER_ERROR_NONE);
     CHECK_EQUAL(VOYAGER_ERROR_NONE, voyager_bootloader_run());
     mock().checkExpectations();
 

--- a/test/test_dfu.cpp
+++ b/test/test_dfu.cpp
@@ -15,7 +15,6 @@ TEST_GROUP(test_dfu){
 
     void setup(){mock().clear();
 mock_nvm_data_t *nvm_data = mock_nvm_get_data();
-nvm_data->app_reset_vector_address = (uintptr_t)&mock_reset_vector;
 
 uint8_t *mock_app_start_address = mock_dfu_get_flash();
 nvm_data->app_start_address = (uintptr_t)mock_app_start_address;


### PR DESCRIPTION
Rrason behind this is that the user may want to do bootloader specific
tasks and calls (such as setting the MSP, cleaning up peripherals)

Topic: jump-to-app-abstraction
Relative:
Reviewers: