### PR TITLE
[Bootloader] Remove option to feature flag flash verification before boot

### DIFF
--- a/inc/voyager.h
+++ b/inc/voyager.h
@@ -39,7 +39,6 @@ typedef enum {
     VOYAGER_NVM_KEY_APP_END_ADDRESS,  // Used to ensure the app size does not
                                       // exceed the max bound
     VOYAGER_NVM_KEY_APP_SIZE,
-    VOYAGER_NVM_KEY_VERIFY_FLASH_BEFORE_JUMPING,
 } voyager_nvm_key_E;
 
 typedef enum {

--- a/src/voyager.c
+++ b/src/voyager.c
@@ -221,29 +221,19 @@ voyager_error_E voyager_private_run_state(const voyager_bootloader_state_E state
                 }
             } break;
             case VOYAGER_STATE_JUMP_TO_APP: {
-                // Get the NVM key for whether we should verify the flash before jumping
-                // to the app
-                voyager_bootloader_nvm_data_t data;
-                ret = voyager_bootloader_nvm_read(VOYAGER_NVM_KEY_VERIFY_FLASH_BEFORE_JUMPING, &data);
-
+                bool flash_verified = false;
+                ret = voyager_private_verify_flash(&flash_verified);
                 if (ret != VOYAGER_ERROR_NONE) {
                     break;
                 }
-                // If we should verify the flash before jumping to the app, we do so
-                if (data.verify_flash_before_jumping) {
-                    bool flash_verified = false;
-                    ret = voyager_private_verify_flash(&flash_verified);
-                    if (ret != VOYAGER_ERROR_NONE) {
-                        break;
-                    }
 
-                    if (flash_verified == false) {
-                        voyager_data.app_failed_crc_check = true;
-                        break;
-                    }
+                if (flash_verified == false) {
+                    voyager_data.app_failed_crc_check = true;
+                    break;
                 }
 
                 // Get the app start address
+                voyager_bootloader_nvm_data_t data;
                 ret = voyager_bootloader_nvm_read(VOYAGER_NVM_KEY_APP_START_ADDRESS, &data);
                 if (ret != VOYAGER_ERROR_NONE) {
                     break;

--- a/test/mocks/mock_nvm.c
+++ b/test/mocks/mock_nvm.c
@@ -24,9 +24,6 @@ voyager_error_E voyager_bootloader_nvm_write(const voyager_nvm_key_E key, voyage
         case VOYAGER_NVM_KEY_APP_END_ADDRESS: {
             mock_nvm_data.app_end_address = data->app_end_address;
         } break;
-        case VOYAGER_NVM_KEY_VERIFY_FLASH_BEFORE_JUMPING: {
-            mock_nvm_data.verify_flash_before_jumping = data->verify_flash_before_jumping;
-        } break;
         default: {
             error = VOYAGER_ERROR_INVALID_ARGUMENT;
         } break;
@@ -49,9 +46,6 @@ voyager_error_E voyager_bootloader_nvm_read(const voyager_nvm_key_E key, voyager
         } break;
         case VOYAGER_NVM_KEY_APP_END_ADDRESS: {
             data->app_end_address = mock_nvm_data.app_end_address;
-        } break;
-        case VOYAGER_NVM_KEY_VERIFY_FLASH_BEFORE_JUMPING: {
-            data->verify_flash_before_jumping = mock_nvm_data.verify_flash_before_jumping;
         } break;
         default: {
             error = VOYAGER_ERROR_INVALID_ARGUMENT;

--- a/test/mocks/mock_nvm.h
+++ b/test/mocks/mock_nvm.h
@@ -9,7 +9,6 @@ typedef struct {
     voyager_bootloader_addr_size_t app_start_address;
     voyager_bootloader_addr_size_t app_end_address;
     voyager_bootloader_app_size_t app_size;
-    voyager_bootloader_verify_flash_before_jumping_t verify_flash_before_jumping;
 } mock_nvm_data_t;
 
 mock_nvm_data_t *mock_nvm_get_data(void);


### PR DESCRIPTION
Enforce the need to verify flash before boot as the bootloader
may be put into weird situations on disconnect and can permit corrupted
flash to execute

Topic: enforce-flash-verification
Relative:
Reviewers: